### PR TITLE
Correct 'commit vs ref' behavior in add

### DIFF
--- a/bade/commands/add.py
+++ b/bade/commands/add.py
@@ -11,11 +11,11 @@ def command(config, repo, commit, upstream, commit_hash):
     """
     puppetfile = utils.PuppetFile(repo)
     puppetfile.load()
-    for key, info in puppetfile.items():
-        if key == 'commit':
-            break
-        if key == 'ref':
-            break
+    if len(puppetfile) and 'commit' in puppetfile.values()[0]:
+        key = 'commit'
+    else:
+        key = 'ref'
+
 
     # update Puppetfile
     branch = utils.get_current_branch(repo)

--- a/bade/utils.py
+++ b/bade/utils.py
@@ -117,6 +117,9 @@ class PuppetFile(object):
             'Puppetfile'
         )
 
+    def __len__(self):
+        return len(self._content)
+
     def __getitem__(self, key):
         return self._content[key]
 


### PR DESCRIPTION
The 'commit vs ref' usage detection logic was broken
in the 'add' command.  It is now fixed -- it looks at the
first item in the Puppetfile, if present.  If that item uses
'commit', 'commit' will be used.  Otherwise, or if no first
item is present, 'ref' is used.  This should work even if no
items are in the Puppetfile.